### PR TITLE
Use MoreUtils for backwards compatability

### DIFF
--- a/perlLib/taxTree.pm
+++ b/perlLib/taxTree.pm
@@ -2,7 +2,7 @@ package taxTree;
 
 use strict;
 use Data::Dumper;
-use List::Util qw/all/;
+use List::MoreUtils qw/all/;
 use Storable qw/dclone/;
 use File::Copy qw/move/;
 


### PR DESCRIPTION
Older List::Util modules don't have "all". Simply specifying MoreUtils will solve this (as is used in the downloadRefSeq.pl script, so there's no extra lib to download).