### PR TITLE
Add skip local files functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -O2 -ggdb -fopenmp -std=c++11 -Isrc -L /data/projects/phillippy/software/boost_1_60_0/lib -I /data/projects/phillippy/software/boost_1_60_0/include 
+CXXFLAGS += -O2 -ggdb -fopenmp -std=c++11 -Isrc -L ../../src/boost/boost_1_61_0/build//lib -I ../../src/boost/boost_1_61_0/build//include 
 CPPFLAGS += -DUSE_BOOST
 
 UNAME_S=$(shell uname -s)
@@ -17,7 +17,7 @@ OBJECTS=$(SOURCES:.cpp=.o)
 all : metamaps
 
 metamaps : $(OBJECTS) 
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OBJECTS) -o metamaps /data/projects/phillippy/software/boost_1_60_0/lib/libboost_math_c99.a -lstdc++ -fopenmp -lz -lm -lpthread -lboost_system -lboost_filesystem -lboost_serialization -lboost_regex
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OBJECTS) -o metamaps ../../src/boost/boost_1_61_0/build//lib/libboost_math_c99.a -lstdc++ -fopenmp -lz -lm -lpthread -lboost_system -lboost_filesystem -lboost_serialization -lboost_regex
 
 .SUFFIXES :
 

--- a/downloadRefSeq.pl
+++ b/downloadRefSeq.pl
@@ -6,6 +6,7 @@ use Data::Dumper;
 use Getopt::Long;
 use Net::FTP;
 use File::Copy;
+use File::Slurp;
 use FindBin;
 use lib "$FindBin::Bin/perlLib";
 use List::MoreUtils qw/all mesh/;
@@ -23,7 +24,7 @@ GetOptions (
 	'seqencesOutDirectory:s' => \$seqencesOutDirectory, 
 	'taxonomyOutDirectory:s' => \$taxonomyOutDirectory, 
 	'targetBranches:s' => \$targetBranches, 
-	'skipIncompleteGenomes:s' => \$skipIncompleteGenomes, 
+	'skipIncompleteGenomes:s' => \$skipIncompleteGenomes,
 );
 
 # Get input arguments
@@ -97,29 +98,42 @@ my $DB_downloaded_assemblies = 0;
 
 $ftp->cwd($ftp_root_genomes . '/' . $DB) or die "Cannot change working directory ", $ftp->message;
 
-foreach my $subDir (@target_subdirs)
+my $report_filename = $seqencesOutDirectory . '/report.txt';
+open(my $report_fh, '>', $report_filename) or die "Could not open file '$report_filename' $!";
+
+SUBDIR: foreach my $subDir (@target_subdirs)
 {
+        my $processed_entries = 1;
 	my $subDir_local = $seqencesOutDirectory . '/' . $subDir;
 	mkdir($subDir_local);
 	die "Directory $subDir_local not existing, but it should (I just tried to mkdir it - do I have write permissions?"  unless(-d $subDir_local);
 	
-	$ftp->cwd($ftp_root_genomes . '/' . $DB . '/'. $subDir . '/') or die "Cannot change working directory ", $ftp->message;		
+	$ftp->cwd($ftp_root_genomes . '/' . $DB . '/'. $subDir . '/') or die "Cannot change working directory ", $ftp->message;
 	
 	my @subDir_content = $ftp->ls();
+        my $num_subdirs = scalar @subDir_content;
+        print "Processing " . $num_subdirs . " entries";
 	my @assembly_summary_files = grep {$_ =~ /assembly_summary.txt/} @subDir_content;
+
 	unless(scalar(@assembly_summary_files) == 1)
 	{
-		die Dumper("Could not identify assembly summary file in " . $ftp_root_genomes . '/' . $DB . '/'. $subDir . '/', \@assembly_summary_files);
+		say $report_fh Dumper("Could not identify assembly summary file in " . $ftp_root_genomes . '/' . $DB . '/'. $subDir . '/', \@assembly_summary_files);
 	}
 	
 	my $assembly_summary_file = $assembly_summary_files[0];
-                     
+        my $assembly_summary_file_local =  $subDir_local . '/' . $assembly_summary_file;
+
 	ATTEMPT: for(my $attempt = 0; $attempt <= 100; $attempt++)
 	{
+                if (-e $assembly_summary_file_local) {
+                  print "\nAssembly summary file exists - skipping.\n";
+                  last ATTEMPT;
+                }
+
 		if($ftp->get($assembly_summary_file))
 		{
 			last ATTEMPT;
-		}	
+		}
 		else
 		{
 			warn "Cannot transfer file " . $ftp->message;	
@@ -133,13 +147,16 @@ foreach my $subDir (@target_subdirs)
 			}
 			if($attempt >= 2)
 			{
-				die "Attempt $attempt to get assembly_summary_file $assembly_summary_file failed";
+				say $report_fh "Attempt $attempt to get assembly_summary_file $assembly_summary_file failed";
+                                next SUBDIR;
 			}
 		}
 	}
-	my $assembly_summary_file_local =  $subDir_local . '/' . $assembly_summary_file;
-	move($assembly_summary_file, $assembly_summary_file_local) or die "Cannot move $assembly_summary_file to $assembly_summary_file_local - current cwd: " . getcwd();
-	
+
+        if (! -e $assembly_summary_file_local) {
+          move($assembly_summary_file, $assembly_summary_file_local) or die "Cannot move $assembly_summary_file to $assembly_summary_file_local - current cwd: " . getcwd();
+	}
+
 	my $assemblies_to_download = 0;
 	my %assembly_dirs_by_species;
 	die "File §assembly_summary_file_local not existing" unless(-e $assembly_summary_file_local);
@@ -154,20 +171,50 @@ foreach my $subDir (@target_subdirs)
 		next unless($_);
 		my @line_fields = split(/\t/, $_, -1);
 		die "Field number mismatch in file $assembly_summary_file_local - $#asmsum_header_fields / $#line_fields" unless(scalar(@asmsum_header_fields) == scalar(@line_fields));
-		my %line = (mesh @asmsum_header_fields, @line_fields);	
+		my %line = (mesh @asmsum_header_fields, @line_fields);
 		my $ftp_path = $line{'ftp_path'};
 		my $assembly_level = $line{'assembly_level'};
 		my $organism_name = $line{'organism_name'};
-		die unless(defined $ftp_path);
-		die unless(defined $assembly_level);
-		next if($skipIncompleteGenomes and ($assembly_level ne 'Complete Genome'));
-		(my $organism_name_safe = $organism_name) =~ s/\W/_/g;
-		push(@{$assembly_dirs_by_species{$organism_name_safe}}, $ftp_path);
-		$assemblies_to_download++;
-		
+		if (defined $ftp_path) {
+  		  die unless(defined $assembly_level);
+		  next if($skipIncompleteGenomes and ($assembly_level ne 'Complete Genome'));
+                  (my $organism_name_safe = $organism_name) =~ s/\W/_/g;
+                  push(@{$assembly_dirs_by_species{$organism_name_safe}}, $ftp_path);
+                  $assemblies_to_download++;
+                }
 	}
 	close(ASMSUM);
-	
+	my $total_dirs = 1;
+        foreach my $check_species_name (keys %assembly_dirs_by_species) {
+          my $check_subdir_species = $subDir_local. '/' . $check_species_name;
+          if (-e $check_subdir_species) {
+            my @check_dirs = read_dir($check_subdir_species);
+            my $num_check_dirs = scalar @check_dirs;
+            my $processed_species_subdirs = 0;
+            my $all_ok = 0;
+            my $checked_dirs = 1;
+            foreach my $dir (@check_dirs) {
+              my @check_files = read_dir($check_subdir_species . '/' . $dir);
+              print "[".$total_dirs."/".(scalar(keys %assembly_dirs_by_species))."] : Checking [" . $checked_dirs . "/" . $num_check_dirs . "]" . $check_subdir_species . '/' . $dir . "\n";
+              my @check_genomic_fna_files = grep {($_ =~ /_genomic.fna.gz$/) or ($_ =~ /_genomic.gff.gz$/) or ($_ =~ /_protein.faa.gz$/)} grep {$_ !~ /(_cds_from_)||(_rna_from_g)/} @check_files;
+              my @check_assembly_report_files = grep {$_ =~ /_assembly_report.txt$/} @check_files;
+              if (@check_genomic_fna_files and @check_assembly_report_files) {
+              }
+              else {
+                $all_ok = 1;
+              }
+              $checked_dirs++;
+            }
+
+            if ($all_ok) {
+              print "[".$total_dirs."/".(scalar(keys %assembly_dirs_by_species))."] : All local files OK\n";
+              delete $assembly_dirs_by_species{$check_species_name};
+              $assemblies_to_download--;
+            }
+          }
+          $total_dirs++;
+        }
+
 	print "Now download genomes for ", scalar(keys %assembly_dirs_by_species), " $subDir species ($assemblies_to_download genomes - ", $DB, " - skip incomplete genomes: $skipIncompleteGenomes).\n";
 		
 	my $downloaded_species = 0;
@@ -176,6 +223,9 @@ foreach my $subDir (@target_subdirs)
 	
 	my $speciesI = 0;
 	
+        # init connection if checking local files takes ages (often get CLOSE_WAIT)
+        initFTP(0);
+
 	my $total_fileI = 0;
 	SPECIES: foreach my $speciesName (keys %assembly_dirs_by_species)
 	{
@@ -188,36 +238,51 @@ foreach my $subDir (@target_subdirs)
 		my $fileI = 0;
 		foreach my $assembly_path_fullURL (@{$assembly_dirs_by_species{$speciesName}})
 		{
-			$fileI++; 
+			$fileI++;
 			$total_fileI++;
 			
-			# last SPECIES  if($downloaded_assemblies > 100);  
+			# last SPECIES  if($downloaded_assemblies > 100);
 			(my $assembly_path_FTP = $assembly_path_fullURL) =~ s/ftp:\/\/ftp.ncbi.nlm.nih.gov//g;
-			$ftp->cwd($assembly_path_FTP) or die "Cannot change working directory into assembly path $assembly_path_FTP ", $ftp->message;		
+			$ftp->cwd($assembly_path_FTP) or do {
+                                say $report_fh "Cannot change working directory into assembly path $assembly_path_FTP " . $ftp->message;
+                                close $report_fh;
+                                die "Cannot change working directory into assembly path $assembly_path_FTP ", $ftp->message;
+                        };
+
 			my @assembly_dir_contents = $ftp->ls();
 	  
 			my @genomic_fna_files = grep {($_ =~ /_genomic.fna.gz$/) or ($_ =~ /_genomic.gff.gz$/) or ($_ =~ /_protein.faa.gz$/)} grep {$_ !~ /(_cds_from_)|(_rna_from_g)/} @assembly_dir_contents;
 			my @assembly_report_files = grep {$_ =~ /_assembly_report.txt$/} @assembly_dir_contents;
-			
-			
-			die "Can't parse assembly version from assembly path: $assembly_path_fullURL" unless($assembly_path_fullURL =~ /.+\/(.+?)$/);
+						
+                        unless($assembly_path_fullURL =~ /.+\/(.+?)$/) {
+                        	say $report_fh $speciesName . ": Can't parse assembly version from assembly path: $assembly_path_fullURL";
+                                next SPECIES;
+                        }
 			my $assembly_version = $1;
 			
-			die Dumper("Problem identifying files for download", \@genomic_fna_files, \@assembly_report_files, $assembly_path_fullURL, $assembly_version) unless((scalar(@assembly_report_files) == 1) and (scalar(@genomic_fna_files) >= 1) and (scalar(@genomic_fna_files) <= 3));
+                        unless((scalar(@assembly_report_files) == 1) and (scalar(@genomic_fna_files) >= 1) and (scalar(@genomic_fna_files) <= 3)) {
+                        	say $report_fh Dumper($speciesName . " [".$assembly_version."] Problem identifying files for download", \@genomic_fna_files, \@assembly_report_files, $assembly_path_fullURL, $assembly_version);
+                                next SPECIES;
+                        }
 			
 			my $assemblyVersion_local = $speciesDir_local . '/'. $assembly_version;
-			mkdir($assemblyVersion_local); 
-			die unless(-d $assemblyVersion_local);	
+			mkdir($assemblyVersion_local);
+			die unless(-d $assemblyVersion_local);
 			
 			my $cwd_before = getcwd();
 			
 			chdir($assemblyVersion_local) or die "Cannot chdir to $assemblyVersion_local";
 			
-			foreach my $file_to_transfer (@genomic_fna_files, @assembly_report_files)
+			FTT: foreach my $file_to_transfer (@genomic_fna_files, @assembly_report_files)
 			{
 				print "\r\t Genome $total_fileI / $assemblies_to_download ; species $speciesI / ", scalar(keys %assembly_dirs_by_species), " $subDir ($speciesName) -- version $fileI / ", scalar(@{$assembly_dirs_by_species{$speciesName}}), ": GET $file_to_transfer                        ";
 				ATTEMPT: for(my $attempt = 0; $attempt <= 100; $attempt++)
 				{
+                                        if (-e $file_to_transfer) {
+                                          print "\nFile exists: [FTP] ", $ftp->size($file_to_transfer), " <=> ", (-s $file_to_transfer), " [LOCAL]\n";
+                                          next FTT if($ftp->size($file_to_transfer) == (-s $file_to_transfer));
+                                        }
+
 					if($ftp->get($file_to_transfer))
 					{
 						last ATTEMPT;
@@ -235,11 +300,12 @@ foreach my $subDir (@target_subdirs)
 						}
 						if($attempt >= 2)
 						{
-							die "Attempt $attempt to get $file_to_transfer failed";
+							say $report_fh "Attempt $attempt to get $file_to_transfer failed";
+                                                        next FTT;
 						}
 					}
 				}
-			}		
+			}
 			
 			# die Dumper($assemblyVersion_local, \@genomic_fna_files); 
 			# print "Downloaded $assembly_version for $speciesDir\n";
@@ -249,7 +315,7 @@ foreach my $subDir (@target_subdirs)
 			chdir($cwd_before) or die "Cannot chdir into $cwd_before";
 		}
 		
-		$downloaded_species++;			
+		$downloaded_species++;
 	}
 	
 	
@@ -259,7 +325,10 @@ foreach my $subDir (@target_subdirs)
 	# print "\tSkipped species (most likely because there is no 'latest_assembly_versions' link in species directory): $skipped_species \n";
 	print "\tDownloaded assemblies: $downloaded_assemblies\n";
 	$DB_downloaded_assemblies += $downloaded_assemblies;
-}	
+}
+
+# close reporting file
+close $report_fh;
 
 print "\nDownload for $DB complete. Have $DB_downloaded_assemblies assemblies.\n";
 

--- a/perlLib/taxTree.pm
+++ b/perlLib/taxTree.pm
@@ -2,7 +2,7 @@ package taxTree;
 
 use strict;
 use Data::Dumper;
-use List::Util qw/all/;
+use List::MoreUtils qw/all/;
 use Storable qw/dclone/;
 use File::Copy qw/move/;
 


### PR DESCRIPTION
The script will still collect up the full list of assemblies, but remove those that are already present on disk. It will now also check that the ftp and local files are the same size if there are files missing in each assembly version download.