### PR TITLE
Update combineAndAnnotateReferences.pl

### DIFF
--- a/combineAndAnnotateReferences.pl
+++ b/combineAndAnnotateReferences.pl
@@ -123,7 +123,7 @@ foreach my $taxonID (keys %taxonID_2_files)
 	{
 		my $thisNode_rank = $taxonomy_href->{$taxonID}{rank};
 		die unless(defined $thisNode_rank);
-		unless(($thisNode_rank eq 'species') or ($thisNode_rank eq 'no rank') or ($thisNode_rank eq 'subspecies') or ($thisNode_rank eq 'varietas'))
+		unless(($thisNode_rank eq 'species') or ($thisNode_rank eq 'no rank') or ($thisNode_rank eq 'subspecies') or ($thisNode_rank eq 'varietas') or ($thisNode_rank eq 'strain') or ($thisNode_rank eq 'isolate'))
 		{
 			die Dumper("Unexpected rank", $thisNode_rank, $taxonID, $taxonID_2_files{$taxonID});
 		}	


### PR DESCRIPTION
Changes allow for strain and isolate rank nodes to be considered. Previously fixed for annotateRefSeqSequencesWithUniqueTaxonIDs.pl . This script now also updated to reflect the same changes.